### PR TITLE
chore: add pre-release support to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - 'v*.*.*-*'
 permissions:
   contents: write
   id-token: write
@@ -34,10 +35,23 @@ jobs:
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
 
+      - name: Determine npm tag and release type
+        id: release-info
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" =~ -.*$ ]]; then
+            echo "npm_tag=next" >> $GITHUB_OUTPUT
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "npm_tag=latest" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag ${{ steps.release-info.outputs.npm_tag }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: ${{ steps.release-info.outputs.is_prerelease == 'true' }}


### PR DESCRIPTION
## Summary

Adds pre-release support to the release workflow, matching the pattern used in `ctrf-js` and `playwright-ctrf-json-reporter`.

### Changes

- Added `v*.*.*-*` tag trigger so pre-release tags (e.g. `v1.0.0-beta.1`) fire the workflow
- Added a "Determine npm tag and release type" step that detects pre-release versions (versions containing `-`)
- Updated `npm publish` to use `--tag next` for pre-releases and `--tag latest` for stable releases
- Updated GitHub Release creation to mark the release as a pre-release when applicable
