### PR TITLE
chore: update ctrf to ^0.2.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
         run: npm publish --provenance --access public --tag ${{ steps.release-info.outputs.npm_tag }}
 
       - name: Create GitHub Release
+        if: steps.release-info.outputs.is_prerelease == 'false'
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@wdio/reporter": "^8.41.0",
-        "ctrf": "^0.2.0-next-0"
+        "ctrf": "^0.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -1633,15 +1633,14 @@
       }
     },
     "node_modules/ctrf": {
-      "version": "0.2.0-next-0",
-      "resolved": "https://registry.npmjs.org/ctrf/-/ctrf-0.2.0-next-0.tgz",
-      "integrity": "sha512-wEh+GoIZtfsbH8lVmGDshFL0jkFmIkD7dbjUeD/qW50MpPHpsfbq5wBfRS3h4aoCi0YJy0acz/w2nesw6CxgJg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ctrf/-/ctrf-0.2.0.tgz",
+      "integrity": "sha512-3tm25Qj6U4Ih10p+rXbobGmQ8udNVGfNnuQ9/L648t5641LkuHcDU6ZTnwClJujhd14xvWc6LPWc57aiYau0tA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "glob": "^13.0.0",
-        "typescript": "^5.8.3",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -2844,6 +2843,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "url": "https://github.com/ctrf-io/.github/blob/main/SECURITY.md"
   },
   "dependencies": {
-    "ctrf": "^0.2.0-next-0",
-    "@wdio/reporter": "^8.41.0"
+    "@wdio/reporter": "^8.41.0",
+    "ctrf": "^0.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",


### PR DESCRIPTION
Update `ctrf` dependency from `^0.2.0-next-0` to `^0.2.0` (stable release).