### PR TITLE
feat: add ctrf namespace to runtime API and bump to v0.0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,67 @@ The test object in the report includes the following [CTRF properties](https://c
 | `flaky`     | Boolean | Optional | Indicates whether the test result is flaky.                                         |
 | `browser`   | String  | Optional | The browser used for the test.                                                      |
 
+## Extra
+
+The `extra` field lets you attach custom metadata to individual test results at runtime. This data is merged into the `extra` field of each test in the CTRF report.
+
+See the [CTRF extra specification](https://www.ctrf.io/docs/specification/extra) for full details.
+
+### Usage
+
+Import `ctrf` from the reporter and call `ctrf.extra()` inside any test:
+
+```javascript
+const { ctrf } = require('wdio-ctrf-json-reporter')
+
+describe('Checkout', () => {
+  it('checkout flow', async () => {
+    ctrf.extra({ owner: 'checkout-team', priority: 'P1' })
+
+    // ... test logic ...
+  })
+})
+```
+
+You can call it multiple times in a single test:
+
+```javascript
+describe('Search', () => {
+  it('search results', async () => {
+    ctrf.extra({ owner: 'search-team' })
+    ctrf.extra({ feature: 'search', environment: 'staging' })
+
+    // ... test logic ...
+
+    ctrf.extra({ customMetric: 'some-value' })
+  })
+})
+```
+
+The resulting `extra` field in the CTRF report:
+
+```json
+{
+  "name": "search results",
+  "status": "passed",
+  "duration": 300,
+  "extra": {
+    "owner": "search-team",
+    "feature": "search",
+    "environment": "staging",
+    "customMetric": "some-value"
+  }
+}
+```
+
+### Merge behaviour
+
+| Data type  | Behaviour                           | Example                                                                                                        |
+| ---------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Primitives | Later call overwrites earlier       | `extra({ owner: 'a' })` then `extra({ owner: 'b' })` → `{ owner: 'b' }`                                        |
+| Objects    | Deep merged - nested keys preserved | `extra({ build: { id: '1' } })` then `extra({ build: { url: '...' } })` → `{ build: { id: '1', url: '...' } }` |
+| Arrays     | Concatenated across calls           | `extra({ tags: ['smoke'] })` then `extra({ tags: ['e2e'] })` → `{ tags: ['smoke', 'e2e'] }`                    |
+
 ## What is CTRF?
 
 CTRF is a universal JSON test report schema that addresses the lack of a standardized format for JSON test reports.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-ctrf-json-reporter",
-  "version": "0.0.16-next-1",
+  "version": "0.0.17",
   "description": "A WebriverIO JSON test reporter to create test results reports",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export {
   type CtrfRuntimeHandler,
   type CtrfRuntimeMessage,
 } from './reporter'
-export { extra } from './runtime'
+export { ctrf, extra } from './runtime'

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -61,5 +61,7 @@ export function extra(data: Record<string, unknown>): void {
   sendMessage({ type: 'extra', data })
 }
 
+export const ctrf = { extra } as const
+
 // Re-export types for convenience
 export { CTRF_RUNTIME_KEY, type CtrfRuntimeHandler, type CtrfRuntimeMessage }


### PR DESCRIPTION
Adds the `ctrf` namespace object to the runtime API for consistency with playwright and cypress reporters.\n\n## Changes\n\n- `src/runtime.ts` — exports `const ctrf = { extra } as const`\n- `src/index.ts` — re-exports `ctrf` alongside `extra`\n- `README.md` — adds `## Extra` section with usage examples, JSON output, and merge behaviour table\n- `package.json` — bumps version to `0.0.17`\n\n## Usage after this change\n\nUsers can now use either:\n```js\nimport { extra } from 'wdio-ctrf-json-reporter'       // existing\nimport { ctrf } from 'wdio-ctrf-json-reporter'         // new\nctrf.extra({ owner: 'team-a' })\n```