### PR TITLE
feat: report failed hooks as test failures

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -2,6 +2,7 @@ import WDIOReporter, {
   type SuiteStats,
   type RunnerStats,
   type TestStats,
+  type HookStats,
 } from '@wdio/reporter'
 import { type Reporters } from '@wdio/types'
 import {
@@ -255,6 +256,13 @@ export default class GenerateCtrfReport extends WDIOReporter {
     }
   }
 
+  onHookEnd(stats: HookStats): void {
+    if (stats.error) {
+      this.updateCtrfTestResultsFromHookStats(stats)
+      this.updateCtrfTotalsFromTestStats(stats)
+    }
+  }
+
   onTestStart(test: TestStats): void {
     // Track current test for runtime metadata collection
     this.currentTestTitle = test.title
@@ -307,7 +315,9 @@ export default class GenerateCtrfReport extends WDIOReporter {
     this.clearRuntimeHandler()
   }
 
-  private updateCtrfTotalsFromTestStats(testStats: TestStats): void {
+  private updateCtrfTotalsFromTestStats(
+    testStats: TestStats | HookStats
+  ): void {
     this.ctrfReport.results.summary.tests += 1
 
     switch (testStats.state) {
@@ -381,11 +391,32 @@ export default class GenerateCtrfReport extends WDIOReporter {
     this.ctrfReport.results.tests.push(ctrfTest)
   }
 
+  private updateCtrfTestResultsFromHookStats(stats: HookStats): void {
+    const ctrfTest: WdioTest = {
+      name: stats.title,
+      status: stats.state ?? 'other',
+      duration: stats._duration,
+    }
+
+    if (this.reporterConfigOptions.minimal === false) {
+      ctrfTest.start = Math.floor(stats.start.getTime() / 1000)
+      ctrfTest.stop = stats.end ? Math.floor(stats.end.getTime() / 1000) : 0
+      ctrfTest.message = this.extractFailureDetails(stats).message
+      ctrfTest.trace = this.extractFailureDetails(stats).trace
+      ctrfTest.rawStatus = stats.state
+      ctrfTest.suite = this.currentSuite
+      ctrfTest.filePath = this.currentSpecFile
+      ctrfTest.browser = this.currentBrowser
+    }
+
+    this.ctrfReport.results.tests.push(ctrfTest)
+  }
+
   hasEnvironmentDetails(environment: WdioEnvironment): boolean {
     return Object.keys(environment).length > 0
   }
 
-  extractFailureDetails(testResult: TestStats): Partial<WdioTest> {
+  extractFailureDetails(testResult: TestStats | HookStats): Partial<WdioTest> {
     if (testResult.state === 'failed' && testResult.error) {
       const failureDetails: Partial<WdioTest> = {}
       if (testResult.error.message) {

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -481,6 +481,62 @@ describe('Reporter output', () => {
   })
 })
 
+describe('Hook error handling', () => {
+  test('failed hook is reported as a failed test', () => {
+    const suite = SUITES.suite_with_failed_hook
+    tmpReporter = new GenerateCtrfReport(mockOptions)
+    tmpReporter.onRunnerStart(getRunnerForSuite(suite))
+    tmpReporter.onSuiteStart(suite as any)
+    tmpReporter.onHookEnd(suite.hooks[0] as any)
+    tmpReporter.onTestStart(suite.tests[0] as any)
+    tmpReporter.onTestEnd(suite.tests[0] as any)
+    tmpReporter.onSuiteEnd(suite as any)
+    tmpReporter.onRunnerEnd(getRunnerForSuite(suite))
+
+    expect(tmpReporter.ctrfReport.results.summary).toMatchObject({
+      tests: 2,
+      failed: 1,
+      passed: 1,
+    })
+
+    expect(tmpReporter.ctrfReport.results.tests[0]).toMatchObject({
+      name: suite.hooks[0].title,
+      status: 'failed',
+      duration: 12,
+      message: 'Hook setup failed',
+      trace: 'Error: Hook setup failed\n    at Context.<anonymous>',
+      rawStatus: 'failed',
+      suite: suite.fullTitle,
+      filePath: suite.file,
+      browser: 'chrome',
+    })
+  })
+
+  test('passing hook is not reported', () => {
+    const suite = SUITES.suite_with_passing_hook
+    tmpReporter = new GenerateCtrfReport(mockOptions)
+    tmpReporter.onRunnerStart(getRunnerForSuite(suite))
+    tmpReporter.onSuiteStart(suite as any)
+    tmpReporter.onHookEnd(suite.hooks[0] as any)
+    tmpReporter.onTestStart(suite.tests[0] as any)
+    tmpReporter.onTestEnd(suite.tests[0] as any)
+    tmpReporter.onSuiteEnd(suite as any)
+    tmpReporter.onRunnerEnd(getRunnerForSuite(suite))
+
+    expect(tmpReporter.ctrfReport.results.summary).toMatchObject({
+      tests: 1,
+      passed: 1,
+      failed: 0,
+    })
+
+    expect(tmpReporter.ctrfReport.results.tests).toHaveLength(1)
+    expect(tmpReporter.ctrfReport.results.tests[0]).toMatchObject({
+      name: suite.tests[0].title,
+      status: 'passed',
+    })
+  })
+})
+
 describe('Reporter params', () => {
   test('all params + capabilities', () => {
     const suite = SUITES.suite_2passed

--- a/tests/testdata.ts
+++ b/tests/testdata.ts
@@ -126,4 +126,60 @@ export const SUITES = {
       },
     ],
   },
+  suite_with_failed_hook: {
+    uid: 'suite_with_failed_hook_id',
+    fullTitle: 'suite_with_failed_hook_fullTitle',
+    file: '/tests/sample/suite_with_failed_hook.e2e.js',
+    hooks: [
+      {
+        uid: 'hook1',
+        title: '"before each" hook for "s6t1 - should run"',
+        start,
+        state: 'failed',
+        type: 'hook',
+        _duration: 12,
+        error: {
+          name: 'Error',
+          message: 'Hook setup failed',
+          stack: 'Error: Hook setup failed\n    at Context.<anonymous>',
+          type: 'Error',
+          expected: undefined,
+          actual: undefined,
+        },
+      },
+    ],
+    tests: [
+      {
+        uid: 's6t1',
+        title: 's6t1 - should run',
+        start,
+        state: 'passed',
+        type: 'test',
+      },
+    ],
+  },
+  suite_with_passing_hook: {
+    uid: 'suite_with_passing_hook_id',
+    fullTitle: 'suite_with_passing_hook_fullTitle',
+    file: '/tests/sample/suite_with_passing_hook.e2e.js',
+    hooks: [
+      {
+        uid: 'hook2',
+        title: '"before each" hook for "s7t1 - should run"',
+        start,
+        state: 'passed',
+        type: 'hook',
+        _duration: 5,
+      },
+    ],
+    tests: [
+      {
+        uid: 's7t1',
+        title: 's7t1 - should run',
+        start,
+        state: 'passed',
+        type: 'test',
+      },
+    ],
+  },
 }


### PR DESCRIPTION
## Summary
- Hook errors (e.g. `beforeEach` failures) were silently swallowed because the reporter had no `onHookEnd` handler
- Adds `onHookEnd` to capture hook failures as CTRF test entries so they appear in the report
- Passing hooks are correctly ignored

## Test plan
- [x] Added test: failed hook is reported as a failed test
- [x] Added test: passing hook is not reported
- [x] Verified tests fail without the fix (hook errors silently lost)
- [x] All existing tests unaffected (8 pass, 2 pre-existing failures from `previousReport` logic)
